### PR TITLE
Add Electron + React boilerplate

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,19 @@
 # clip-bridge
-Lightweight clipboard-sharing bridge that syncs copy/paste between firewall-restricted machines via HTTP polling.
+
+Electron + React desktop application for sharing clipboard contents across devices.
+
+## Development
+
+```bash
+npm install
+npm run start
+```
+
+This runs the React development server and Electron together.
+
+## Packaging
+
+```
+npm run build
+npm run package
+```

--- a/package.json
+++ b/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "clip-bridge",
+  "version": "0.1.0",
+  "main": "src/main.js",
+  "scripts": {
+    "react-start": "react-scripts start",
+    "electron-start": "wait-on http://localhost:3000 && electron .",
+    "start": "concurrently \"npm run react-start\" \"npm run electron-start\"",
+    "build": "react-scripts build",
+    "package": "electron-builder"
+  },
+  "dependencies": {
+    "@emotion/react": "^11.11.1",
+    "@emotion/styled": "^11.11.0",
+    "@mui/icons-material": "^5.11.16",
+    "@mui/material": "^5.13.7",
+    "concurrently": "^8.2.0",
+    "electron": "^26.0.0",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "electron-builder": "^24.6.0",
+    "wait-on": "^7.0.1",
+    "react-scripts": "5.0.1"
+  },
+  "build": {
+    "appId": "com.example.clipbridge",
+    "files": [
+      "build/**/*",
+      "src/main.js",
+      "src/preload.js"
+    ],
+    "directories": {
+      "buildResources": "assets"
+    }
+  }
+}

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Clip Bridge</title>
+  </head>
+  <body>
+    <div id="root"></div>
+  </body>
+</html>

--- a/src/main.js
+++ b/src/main.js
@@ -1,0 +1,41 @@
+const { app, BrowserWindow, ipcMain, clipboard } = require('electron');
+const path = require('path');
+
+const isDev = process.env.NODE_ENV === 'development';
+
+function createWindow() {
+  const win = new BrowserWindow({
+    width: 800,
+    height: 600,
+    webPreferences: {
+      preload: path.join(__dirname, 'preload.js'),
+      contextIsolation: true,
+    },
+  });
+
+  if (isDev) {
+    win.loadURL('http://localhost:3000');
+  } else {
+    win.loadFile(path.join(__dirname, '../build/index.html'));
+  }
+}
+
+app.whenReady().then(() => {
+  createWindow();
+
+  app.on('activate', function () {
+    if (BrowserWindow.getAllWindows().length === 0) createWindow();
+  });
+});
+
+app.on('window-all-closed', function () {
+  if (process.platform !== 'darwin') app.quit();
+});
+
+ipcMain.handle('get-clipboard', () => {
+  return clipboard.readText();
+});
+
+ipcMain.handle('set-clipboard', (event, text) => {
+  clipboard.writeText(text);
+});

--- a/src/preload.js
+++ b/src/preload.js
@@ -1,0 +1,6 @@
+const { contextBridge, ipcRenderer } = require('electron');
+
+contextBridge.exposeInMainWorld('api', {
+  getClipboard: () => ipcRenderer.invoke('get-clipboard'),
+  setClipboard: (text) => ipcRenderer.invoke('set-clipboard', text),
+});

--- a/src/renderer/App.jsx
+++ b/src/renderer/App.jsx
@@ -1,0 +1,68 @@
+import React, { useState } from 'react';
+import { AppBar, Toolbar, IconButton, Typography, Box, Paper, Divider, BottomNavigation, BottomNavigationAction, Card, CardContent, Button, Stack } from '@mui/material';
+import MenuIcon from '@mui/icons-material/Menu';
+import SettingsIcon from '@mui/icons-material/Settings';
+import ContentCopyIcon from '@mui/icons-material/ContentCopy';
+import ContentPasteIcon from '@mui/icons-material/ContentPaste';
+import RefreshIcon from '@mui/icons-material/Refresh';
+import FilterListIcon from '@mui/icons-material/FilterList';
+import HistoryIcon from '@mui/icons-material/History';
+import DevicesIcon from '@mui/icons-material/Devices';
+import GridViewIcon from '@mui/icons-material/GridView';
+
+import DeviceCard from './components/DeviceCard';
+
+export default function App() {
+  const [tab, setTab] = useState(0);
+
+  const devices = [
+    { name: 'PTOP-880OUEHO.china...', ip: '192.168.2.33' },
+    { name: 'LAPTOP-12345.home', ip: '192.168.2.34' }
+  ];
+
+  return (
+    <Box sx={{ height: '100vh', display: 'flex', flexDirection: 'column' }}>
+      <AppBar position="static">
+        <Toolbar>
+          <IconButton edge="start" color="inherit">
+            <MenuIcon />
+          </IconButton>
+          <Typography variant="h6" sx={{ flexGrow: 1 }} align="center">
+            Clipboard Remote
+          </Typography>
+          <IconButton color="inherit">
+            <SettingsIcon />
+          </IconButton>
+        </Toolbar>
+      </AppBar>
+
+      <Box sx={{ p: 2, flexGrow: 1, overflow: 'auto' }}>
+        <Paper sx={{ p: 2, mb: 2 }}>
+          <Typography variant="h5">React + Electron</Typography>
+        </Paper>
+        <Divider sx={{ my: 2, cursor: 'row-resize' }} />
+        <Box>
+          <Box sx={{ display: 'flex', justifyContent: 'flex-end', mb: 1 }}>
+            <IconButton size="small">
+              <RefreshIcon />
+            </IconButton>
+            <IconButton size="small">
+              <FilterListIcon />
+            </IconButton>
+          </Box>
+          <Stack spacing={2}>
+            {devices.map((d, idx) => (
+              <DeviceCard key={idx} name={d.name} ip={d.ip} />
+            ))}
+          </Stack>
+        </Box>
+      </Box>
+
+      <BottomNavigation value={tab} onChange={(_, v) => setTab(v)}>
+        <BottomNavigationAction label="Clipboard" icon={<ContentCopyIcon />} />
+        <BottomNavigationAction label="History" icon={<HistoryIcon />} />
+        <BottomNavigationAction label="Devices" icon={<DevicesIcon />} />
+      </BottomNavigation>
+    </Box>
+  );
+}

--- a/src/renderer/components/DeviceCard.jsx
+++ b/src/renderer/components/DeviceCard.jsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { Card, CardContent, Typography, IconButton, Stack } from '@mui/material';
+import ContentPasteGoIcon from '@mui/icons-material/ContentPaste';
+import ContentCopyIcon from '@mui/icons-material/ContentCopy';
+import GridViewIcon from '@mui/icons-material/GridView';
+
+export default function DeviceCard({ name, ip }) {
+  return (
+    <Card variant="outlined">
+      <CardContent sx={{ display: 'flex', alignItems: 'center', gap: 2 }}>
+        <GridViewIcon />
+        <Stack sx={{ flexGrow: 1 }}>
+          <Typography variant="subtitle1">{name}</Typography>
+          <Typography variant="caption" color="text.secondary">{ip}</Typography>
+        </Stack>
+        <IconButton size="small" aria-label="copy">
+          <ContentCopyIcon />
+        </IconButton>
+        <IconButton size="small" aria-label="paste">
+          <ContentPasteGoIcon />
+        </IconButton>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/renderer/index.jsx
+++ b/src/renderer/index.jsx
@@ -1,0 +1,6 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+
+const root = ReactDOM.createRoot(document.getElementById('root'));
+root.render(<App />);


### PR DESCRIPTION
## Summary
- init Electron main and preload scripts
- add React app with Material UI layout
- wire up concurrently and electron-builder via package.json

## Testing
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68706373c8c08324a366a2a5a3eac2d7