### PR TITLE
Fix electron window size

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -5,8 +5,11 @@ const isDev = process.env.NODE_ENV === 'development';
 
 function createWindow() {
   const win = new BrowserWindow({
-    width: 800,
-    height: 600,
+    width: 540,
+    height: 835,
+    resizable: false,
+    maximizable: false,
+    fullscreenable: false,
     webPreferences: {
       preload: path.join(__dirname, 'preload.js'),
       contextIsolation: true,


### PR DESCRIPTION
## Summary
- set default Electron window width and height
- disable resizing and maximizing to keep window fixed

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68712b7843b0832497a296797d232884